### PR TITLE
Feat: Custom cipher and decipher functions

### DIFF
--- a/src/encryption.test.ts
+++ b/src/encryption.test.ts
@@ -110,7 +110,7 @@ describe('encryption', () => {
   describe('decryptOnRead', () => {
     test('Should call custom decryp function', async () => {
       const decryptFunction = jest.fn(
-        (encrypted: string) => `fake-encription-${encrypted}`
+        (encrypted: string) => `fake-decription-${encrypted}`
       )
 
       const params: MiddlewareParams = {

--- a/src/encryption.test.ts
+++ b/src/encryption.test.ts
@@ -4,27 +4,11 @@ import { MiddlewareParams } from 'types'
 import { configureKeys, encryptOnWrite, KeysConfiguration } from './encryption'
 import { errors } from './errors'
 
-const TEST_KEY = 'k1.aesgcm256.DbQoar8ZLuUsOHZNyrnjlskInHDYlzF3q6y1KGM7DUM='
-
-const encryptFunction = jest.fn(
-  (decripted: string) => `fake-encription-${decripted}`
-)
-const decryptFunction = jest.fn(
-  (encripted: string) => `fake-decription-${encripted}`
-)
-const fakeKeys: KeysConfiguration = {
-  encryptionKey: 'fake-encryptionKey',
-  keychain: 'fake-keychain'
-} as any
-const fakeParams: MiddlewareParams = {
-  action: 'create',
-  args: { data: { any: 'field' } },
-  dataPath: ['any'],
-  runInTransaction: true,
-  model: 'User'
-}
-const fakeModels: DMMFModels = { User: null } as any
-const fakeOperation = 'User.create'
+const ENCRYPTION_TEST_KEY = 'k1.aesgcm256.DbQoar8ZLuUsOHZNyrnjlskInHDYlzF3q6y1KGM7DUM='
+const DECRYPTION_TEST_KEY = [
+  'k1.aesgcm256.4BNYdJnjOQJP2adq9cGM9kb4dZxDujUs6aPS0VeRtAM=',
+  'k1.aesgcm256.El9unG7WBAVRQdATOyMggE3XrLV2ZjTGKdajfmIeBPs='
+]
 
 describe('encryption', () => {
   describe('configureKeys', () => {
@@ -35,44 +19,39 @@ describe('encryption', () => {
 
     test('Providing encryptionKey directly', () => {
       const { encryptionKey } = configureKeys({
-        encryptionKey: TEST_KEY
+        encryptionKey: ENCRYPTION_TEST_KEY
       })
-      expect(formatKey(encryptionKey.raw as Uint8Array)).toEqual(TEST_KEY)
+
+      expect(formatKey(encryptionKey.raw as Uint8Array)).toEqual(ENCRYPTION_TEST_KEY)
     })
 
     test('Providing encryptionKey via the environment', () => {
-      process.env.PRISMA_FIELD_ENCRYPTION_KEY = TEST_KEY
+      process.env.PRISMA_FIELD_ENCRYPTION_KEY = ENCRYPTION_TEST_KEY
       const { encryptionKey } = configureKeys({})
-      expect(formatKey(encryptionKey.raw as Uint8Array)).toEqual(TEST_KEY)
+      expect(formatKey(encryptionKey.raw as Uint8Array)).toEqual(ENCRYPTION_TEST_KEY)
       process.env.PRISMA_FIELD_ENCRYPTION_KEY = undefined
     })
 
     test('Encryption key is in the keychain', () => {
       const { encryptionKey, keychain } = configureKeys({
-        encryptionKey: TEST_KEY
+        encryptionKey: ENCRYPTION_TEST_KEY
       })
       expect(keychain[encryptionKey.fingerprint].key).toEqual(encryptionKey)
     })
 
     test('Loading decryption keys directly', () => {
       const { keychain } = configureKeys({
-        encryptionKey: TEST_KEY,
-        decryptionKeys: [
-          'k1.aesgcm256.4BNYdJnjOQJP2adq9cGM9kb4dZxDujUs6aPS0VeRtAM=',
-          'k1.aesgcm256.El9unG7WBAVRQdATOyMggE3XrLV2ZjTGKdajfmIeBPs='
-        ]
+        encryptionKey: ENCRYPTION_TEST_KEY,
+        decryptionKeys: DECRYPTION_TEST_KEY
       })
       expect(Object.values(keychain).length).toEqual(3)
     })
 
     test('Loading decryption keys via the environment', () => {
-      process.env.PRISMA_FIELD_DECRYPTION_KEYS = [
-        'k1.aesgcm256.4BNYdJnjOQJP2adq9cGM9kb4dZxDujUs6aPS0VeRtAM=',
-        'k1.aesgcm256.El9unG7WBAVRQdATOyMggE3XrLV2ZjTGKdajfmIeBPs='
-      ].join(',')
+      process.env.PRISMA_FIELD_DECRYPTION_KEYS = DECRYPTION_TEST_KEY.join(',')
 
       const { keychain } = configureKeys({
-        encryptionKey: TEST_KEY
+        encryptionKey: ENCRYPTION_TEST_KEY
       })
       expect(Object.values(keychain).length).toEqual(3)
       process.env.PRISMA_FIELD_DECRYPTION_KEYS = undefined
@@ -80,12 +59,42 @@ describe('encryption', () => {
   })
 
   describe('encryptOnWrite', () => {
-    test('Should call custom encrypt function', () => {
+    test('Should call custom encrypt function', async () => {
+
+      const encryptFunction = jest.fn(
+        (decripted: string) => `fake-encription-${decripted}`
+      )
+
+      const params: MiddlewareParams = {
+        action: 'create',
+        args: { data: { name: 'value' } },
+        dataPath: ['any'],
+        runInTransaction: true,
+        model: 'User'
+      }
+      
+      const dmmfModels: DMMFModels = {
+        User: {
+          connections: {},
+          fields: {
+            name: {
+              encrypt: true,
+              strictDecryption: true
+            }
+          }
+        }
+      }
+
+      const keys = configureKeys({ 
+        encryptionKey: ENCRYPTION_TEST_KEY, 
+        decryptionKeys: DECRYPTION_TEST_KEY
+      })
+
       encryptOnWrite(
-        fakeParams,
-        fakeKeys,
-        fakeModels,
-        fakeOperation,
+        params,
+        keys,
+        dmmfModels,
+        'User.create',
         encryptFunction
       )
 

--- a/src/encryption.test.ts
+++ b/src/encryption.test.ts
@@ -1,11 +1,12 @@
 import { formatKey } from '@47ng/cloak/dist/key'
 import { DMMFModels } from 'dmmf'
 import { MiddlewareParams } from 'types'
-import { configureKeys, encryptOnWrite, KeysConfiguration } from './encryption'
+import { configureKeys, decryptOnRead, encryptOnWrite } from './encryption'
 import { errors } from './errors'
 
-const ENCRYPTION_TEST_KEY = 'k1.aesgcm256.DbQoar8ZLuUsOHZNyrnjlskInHDYlzF3q6y1KGM7DUM='
-const DECRYPTION_TEST_KEY = [
+const ENCRYPTION_TEST_KEY =
+  'k1.aesgcm256.DbQoar8ZLuUsOHZNyrnjlskInHDYlzF3q6y1KGM7DUM='
+const DECRYPTION_TEST_KEYS = [
   'k1.aesgcm256.4BNYdJnjOQJP2adq9cGM9kb4dZxDujUs6aPS0VeRtAM=',
   'k1.aesgcm256.El9unG7WBAVRQdATOyMggE3XrLV2ZjTGKdajfmIeBPs='
 ]
@@ -22,13 +23,17 @@ describe('encryption', () => {
         encryptionKey: ENCRYPTION_TEST_KEY
       })
 
-      expect(formatKey(encryptionKey.raw as Uint8Array)).toEqual(ENCRYPTION_TEST_KEY)
+      expect(formatKey(encryptionKey.raw as Uint8Array)).toEqual(
+        ENCRYPTION_TEST_KEY
+      )
     })
 
     test('Providing encryptionKey via the environment', () => {
       process.env.PRISMA_FIELD_ENCRYPTION_KEY = ENCRYPTION_TEST_KEY
       const { encryptionKey } = configureKeys({})
-      expect(formatKey(encryptionKey.raw as Uint8Array)).toEqual(ENCRYPTION_TEST_KEY)
+      expect(formatKey(encryptionKey.raw as Uint8Array)).toEqual(
+        ENCRYPTION_TEST_KEY
+      )
       process.env.PRISMA_FIELD_ENCRYPTION_KEY = undefined
     })
 
@@ -42,13 +47,13 @@ describe('encryption', () => {
     test('Loading decryption keys directly', () => {
       const { keychain } = configureKeys({
         encryptionKey: ENCRYPTION_TEST_KEY,
-        decryptionKeys: DECRYPTION_TEST_KEY
+        decryptionKeys: DECRYPTION_TEST_KEYS
       })
       expect(Object.values(keychain).length).toEqual(3)
     })
 
     test('Loading decryption keys via the environment', () => {
-      process.env.PRISMA_FIELD_DECRYPTION_KEYS = DECRYPTION_TEST_KEY.join(',')
+      process.env.PRISMA_FIELD_DECRYPTION_KEYS = DECRYPTION_TEST_KEYS.join(',')
 
       const { keychain } = configureKeys({
         encryptionKey: ENCRYPTION_TEST_KEY
@@ -60,45 +65,98 @@ describe('encryption', () => {
 
   describe('encryptOnWrite', () => {
     test('Should call custom encrypt function', async () => {
-
       const encryptFunction = jest.fn(
         (decripted: string) => `fake-encription-${decripted}`
       )
 
+      const name = 'value'
       const params: MiddlewareParams = {
+        model: 'User',
         action: 'create',
-        args: { data: { name: 'value' } },
-        dataPath: ['any'],
+        args: { data: { name } },
         runInTransaction: true,
-        model: 'User'
+        dataPath: ['any']
       }
-      
+
       const dmmfModels: DMMFModels = {
         User: {
-          connections: {},
+          connections: {
+            'fake-connection': {
+              modelName: 'User',
+              isList: false
+            }
+          },
           fields: {
             name: {
               encrypt: true,
-              strictDecryption: true
+              strictDecryption: false
             }
           }
         }
       }
 
-      const keys = configureKeys({ 
-        encryptionKey: ENCRYPTION_TEST_KEY, 
-        decryptionKeys: DECRYPTION_TEST_KEY
+      const keys = configureKeys({
+        encryptionKey: ENCRYPTION_TEST_KEY,
+        decryptionKeys: DECRYPTION_TEST_KEYS
       })
 
-      encryptOnWrite(
-        params,
-        keys,
-        dmmfModels,
-        'User.create',
-        encryptFunction
-      )
+      encryptOnWrite(params, keys, dmmfModels, 'User.create', encryptFunction)
 
       expect(encryptFunction).toBeCalledTimes(1)
+      expect(encryptFunction).toBeCalledWith(name)
+    })
+  })
+
+  describe('decryptOnRead', () => {
+    test('Should call custom decryp function', async () => {
+      const decryptFunction = jest.fn(
+        (encrypted: string) => `fake-encription-${encrypted}`
+      )
+
+      const params: MiddlewareParams = {
+        model: 'User',
+        action: 'findFirst',
+        args: { where: { name: 'value' } },
+        runInTransaction: true,
+        dataPath: ['any']
+      }
+
+      const dmmfModels: DMMFModels = {
+        User: {
+          connections: {
+            'fake-connection': {
+              modelName: 'User',
+              isList: false
+            }
+          },
+          fields: {
+            name: {
+              encrypt: true,
+              strictDecryption: false
+            }
+          }
+        }
+      }
+
+      const keys = configureKeys({
+        encryptionKey: ENCRYPTION_TEST_KEY,
+        decryptionKeys: DECRYPTION_TEST_KEYS
+      })
+
+      const encryptedName = 'a1b2c3d4e5d6'
+      const result = { name: encryptedName }
+
+      decryptOnRead(
+        params,
+        result,
+        keys,
+        dmmfModels,
+        'User.findFirst',
+        decryptFunction
+      )
+
+      expect(decryptFunction).toBeCalledTimes(1)
+      expect(decryptFunction).toBeCalledWith(encryptedName)
     })
   })
 })

--- a/src/encryption.test.ts
+++ b/src/encryption.test.ts
@@ -1,8 +1,30 @@
 import { formatKey } from '@47ng/cloak/dist/key'
-import { configureKeys } from './encryption'
+import { DMMFModels } from 'dmmf'
+import { MiddlewareParams } from 'types'
+import { configureKeys, encryptOnWrite, KeysConfiguration } from './encryption'
 import { errors } from './errors'
 
 const TEST_KEY = 'k1.aesgcm256.DbQoar8ZLuUsOHZNyrnjlskInHDYlzF3q6y1KGM7DUM='
+
+const encryptFunction = jest.fn(
+  (decripted: string) => `fake-encription-${decripted}`
+)
+const decryptFunction = jest.fn(
+  (encripted: string) => `fake-decription-${encripted}`
+)
+const fakeKeys: KeysConfiguration = {
+  encryptionKey: 'fake-encryptionKey',
+  keychain: 'fake-keychain'
+} as any
+const fakeParams: MiddlewareParams = {
+  action: 'create',
+  args: { data: { any: 'field' } },
+  dataPath: ['any'],
+  runInTransaction: true,
+  model: 'User'
+}
+const fakeModels: DMMFModels = { User: null } as any
+const fakeOperation = 'User.create'
 
 describe('encryption', () => {
   describe('configureKeys', () => {
@@ -54,6 +76,20 @@ describe('encryption', () => {
       })
       expect(Object.values(keychain).length).toEqual(3)
       process.env.PRISMA_FIELD_DECRYPTION_KEYS = undefined
+    })
+  })
+
+  describe('encryptOnWrite', () => {
+    test('Should call custom encrypt function', () => {
+      encryptOnWrite(
+        fakeParams,
+        fakeKeys,
+        fakeModels,
+        fakeOperation,
+        encryptFunction
+      )
+
+      expect(encryptFunction).toBeCalledTimes(1)
     })
   })
 })

--- a/src/encryption.ts
+++ b/src/encryption.ts
@@ -15,8 +15,8 @@ import { errors, warnings } from './errors'
 import type {
   Configuration,
   MiddlewareParams,
-  EncryptionFunction,
-  DecryptionFunction
+  EncryptionFn,
+  DecryptionFn
 } from './types'
 import { visitInputTargetFields, visitOutputTargetFields } from './visitor'
 
@@ -69,7 +69,7 @@ export function encryptOnWrite(
   keys: KeysConfiguration,
   models: DMMFModels,
   operation: string,
-  cb?: EncryptionFunction
+  encryptFn?: EncryptionFn
 ) {
   if (!writeOperations.includes(params.action)) {
     return params // No input data to encrypt
@@ -96,8 +96,8 @@ export function encryptOnWrite(
         }
         try {
           const cipherText =
-            cb !== undefined
-              ? cb(clearText)
+            encryptFn !== undefined
+              ? encryptFn(clearText)
               : encryptStringSync(clearText, keys.encryptionKey)
 
           objectPath.set(draft.args, path, cipherText)
@@ -121,7 +121,7 @@ export function decryptOnRead(
   keys: KeysConfiguration,
   models: DMMFModels,
   operation: string,
-  cb?: DecryptionFunction
+  decryptFn?: DecryptionFn
 ) {
   // Analyse the query to see if there's anything to decrypt.
   const model = models[params.model!]
@@ -153,8 +153,8 @@ export function decryptOnRead(
         }
         const decryptionKey = findKeyForMessage(cipherText, keys.keychain)
         const clearText =
-          cb !== undefined
-            ? cb(cipherText)
+          decryptFn !== undefined
+            ? decryptFn(cipherText)
             : decryptStringSync(cipherText, decryptionKey)
 
         objectPath.set(result, path, clearText)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,10 @@
 import { analyseDMMF } from './dmmf'
-import { configureKeys, decryptOnRead, encryptOnWrite } from './encryption'
+import {
+  configureKeys,
+  decryptOnRead,
+  encryptOnWrite,
+  ConfigureKeysParams
+} from './encryption'
 import type { Configuration, Middleware, MiddlewareParams } from './types'
 
 export function fieldEncryptionMiddleware(
@@ -7,7 +12,12 @@ export function fieldEncryptionMiddleware(
 ): Middleware {
   // This will throw if the encryption key is missing
   // or if anything is invalid.
-  const keys = configureKeys(config)
+  const configureKeysParams: ConfigureKeysParams = {
+    encryptionKey: config.encryptionKey,
+    decryptionKeys: config.decryptionKeys
+  }
+
+  const keys = configureKeys(configureKeysParams)
   const models = analyseDMMF()
 
   return async function fieldEncryptionMiddleware(

--- a/src/traverseTree.ts
+++ b/src/traverseTree.ts
@@ -43,6 +43,9 @@ export function traverseTree<State>(
 
   while (stack.length > 0) {
     const { state, ...item } = stack.shift()!
+
+    console.log('CALLBACK')
+
     const newState = callback(state, item)
     if (!isCollection(item.node)) {
       continue

--- a/src/traverseTree.ts
+++ b/src/traverseTree.ts
@@ -44,8 +44,6 @@ export function traverseTree<State>(
   while (stack.length > 0) {
     const { state, ...item } = stack.shift()!
 
-    console.log('CALLBACK')
-
     const newState = callback(state, item)
     if (!isCollection(item.node)) {
       continue

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,15 +8,15 @@ export type DMMF = typeof Prisma.dmmf
 
 // Internal types --
 
-export type EncryptionFunction = (value: string) => string
+export type EncryptionFn = (value: string) => string
 
-export type DecryptionFunction = (value: string) => string
+export type DecryptionFn = (value: string) => string
 
 export interface Configuration {
   encryptionKey?: string
   decryptionKeys?: string[]
-  encryptionFn?: EncryptionFunction
-  decryptionFn?: DecryptionFunction
+  encryptionFn?: EncryptionFn
+  decryptionFn?: DecryptionFn
 }
 
 export interface FieldConfiguration {

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,9 +8,15 @@ export type DMMF = typeof Prisma.dmmf
 
 // Internal types --
 
+export type EncryptionFunction = (value: string) => string
+
+export type DecryptionFunction = (value: string) => string
+
 export interface Configuration {
   encryptionKey?: string
   decryptionKeys?: string[]
+  encryptionFn?: EncryptionFunction
+  decryptionFn?: DecryptionFunction
 }
 
 export interface FieldConfiguration {

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -16,7 +16,10 @@ export interface TargetField {
 
 export type TargetFieldVisitorFn = (targetField: TargetField) => void
 
-const makeVisitor = (models: DMMFModels, visitor: TargetFieldVisitorFn) =>
+export const makeVisitor = (
+  models: DMMFModels,
+  visitor: TargetFieldVisitorFn
+) =>
   function visitNode(state: VisitorState, { key, type, node, path }: Item) {
     const model = models[state.currentModel]
     if (!model || !key) {


### PR DESCRIPTION
It is currently not possible to pass custom encryption and decryption methods as params, and this creates a problem: It is not possible to filter db data by encrypted fields, as the current encryption library always generates a different hash for the same text.

This PR aims to allow custom encryption/decryption function to be passed as params, so if the developer wants to filter data by ciphertext, he can use any lib that generates static hash's, for example.