### PR TITLE
fix: Consider select for field decryption

### DIFF
--- a/src/encryption.ts
+++ b/src/encryption.ts
@@ -135,7 +135,7 @@ export function decryptOnRead<Models extends string, Actions extends string>(
 ) {
   // Analyse the query to see if there's anything to decrypt.
   const model = models[params.model!]
-  if (Object.keys(model.fields).length === 0 && !params.args?.include) {
+  if (Object.keys(model.fields).length === 0 && !params.args?.include && !params.args?.select) {
     // The queried model doesn't have any encrypted field,
     // and there are no included connections.
     // We can safely skip decryption for the returned data.

--- a/src/tests/integration.test.ts
+++ b/src/tests/integration.test.ts
@@ -184,6 +184,49 @@ describe('integration', () => {
     expect(category.name).toEqual('Quotes')
   })
 
+  test('top level with no encrypted field, nested with encrypted field - using select', async () => {
+    const created = await client.post.create({
+      data: {
+        title: "I'm back",
+        content: 'You only live twice.',
+        categories: {
+          create : {
+            name: 'Secret agents'
+          }
+        },
+        author: {
+          create: {
+            email: '005@hmss.gov.uk',
+            name: 'James Bond'
+          }
+        }
+      },
+      select: {
+        id: true,
+        author: true,
+        content: true,
+        categories: true
+      }
+    })
+
+    const category = await client.category.findFirst({
+      select: {
+        name: true,
+        posts: {
+          select: {
+            content: true
+          }
+        },
+      },
+      where: {
+        id: { equals: created.categories![0].id}
+      }
+    })
+
+    expect(category?.name).toEqual('Secret agents')
+    expect(category?.posts[0].content).toEqual('You only live twice.')
+  })
+
   test('immutable params', async () => {
     const email = 'xenia@cccp.ru'
     const params = {


### PR DESCRIPTION
Hi there! Nice lib!

I have come across a use case where I could not query nested encrypted fields if the top level model had no encrypted fields.

Consider the following model:

```prisma
model JobPosition {
  id String @id @default(uuid())
  createdAt DateTime @updatedAt
  name String
  job Job @relation(fields: [jobId], references: [id])
  jobId String
  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
  userId String
}

model User {
  id String @id @default(uuid())
  email String? @unique
  pin String @unique /// @encrypted
  pinHash String? @unique /// @encryption:hash(pin)
  profile Profile @relation(fields: [profileId], references: [id])
  profileId String
  createdAt DateTime
  jobPositions JobPosition[]
  roles String[]
}
```

And the following query:

```ts
const jobPosition = await prisma.jobPosition.findFirst({
    select: {
      user: {
        select: {
          pin: true,
        }
      }
    },
    where: {
      user: {
        id: {
          equals: 'eid-1'
        }
      }
    }
  })

  console.log(jobPosition?.user.pin);  // outputs v1.aesgcm256...
```

The output pin will be `v1.aesgcm256...`. I expect to see an unencrypted pin.

I have made a fix + added a test case.

I am not sure if my simple fix within this query is performing enough, but all the tests + this new test case pass. If you have a better idea, let me know!