### PR TITLE
fix: `Maximum call stack size exceeded` in `traverseTree`

### DIFF
--- a/src/traverseTree.test.ts
+++ b/src/traverseTree.test.ts
@@ -359,9 +359,15 @@ describe('traverseTree', () => {
     ])
   })
 
+  const leaf = (index: number) => ({
+    hello: 'world',
+    index
+  })
+  const array = Array.from({ length: 1_000_000 }, (_, i) => leaf(i))
+
   test('root node is an array with 1 million rows', () => {
     const visitor = jest.fn().mockImplementation(state => state)
-    traverseTree(Array.from(Array(1000000).keys()), visitor, null)
-    expect(visitor).toHaveBeenCalledTimes(1000001)
+    traverseTree(array, visitor, null)
+    expect(visitor).toHaveBeenCalledTimes(3000001)
   })
 })

--- a/src/traverseTree.test.ts
+++ b/src/traverseTree.test.ts
@@ -358,4 +358,10 @@ describe('traverseTree', () => {
       ]
     ])
   })
+
+  test('root node is an array with 1 million rows', () => {
+    const visitor = jest.fn().mockImplementation(state => state)
+    traverseTree(Array.from(Array(1000000).keys()), visitor, null)
+    expect(visitor).toHaveBeenCalledTimes(1000001)
+  })
 })

--- a/src/traverseTree.ts
+++ b/src/traverseTree.ts
@@ -32,7 +32,7 @@ export function traverseTree<State>(
     state: State
   }
 
-  let stack: StackItem[] = [
+  const stack: StackItem[] = [
     {
       path: [],
       type: typeOf(input),
@@ -56,7 +56,9 @@ export function traverseTree<State>(
         state: newState
       })
     )
-    stack = [...stack, ...children.reverse()]
+    for (let i = children.length - 1; i >= 0; --i) {
+      stack.push(children[i])
+    }
   }
 }
 

--- a/src/traverseTree.ts
+++ b/src/traverseTree.ts
@@ -32,7 +32,7 @@ export function traverseTree<State>(
     state: State
   }
 
-  const stack: StackItem[] = [
+  let stack: StackItem[] = [
     {
       path: [],
       type: typeOf(input),
@@ -42,7 +42,7 @@ export function traverseTree<State>(
   ]
 
   while (stack.length > 0) {
-    const { state, ...item } = stack.shift()!
+    const { state, ...item } = stack.pop()!
     const newState = callback(state, item)
     if (!isCollection(item.node)) {
       continue
@@ -56,7 +56,7 @@ export function traverseTree<State>(
         state: newState
       })
     )
-    stack.unshift(...children)
+    stack = [...stack, ...children.reverse()]
   }
 }
 


### PR DESCRIPTION
If `prisma-field-encryption` is used as middleware:

When working with a table (that may or may not use prisma-field-encryption) that has lots of rows/data, calling `stack.unshift(...children)` may fail with:

```
RangeError: Maximum call stack size exceeded
```

This is because `children` is too large to be passed on the stack as arguments to `unshift`.

I noticed this happening when calling `prisma.<table>.findMany()` and expecting a large amount of data back:

The presence of `prisma-field-encryption` in the middleware will cause the call to fail with the error above.