### PR TITLE
fix: Add support for BigInt as a CursorType

### DIFF
--- a/src/dmmf.ts
+++ b/src/dmmf.ts
@@ -26,7 +26,6 @@ export interface DMMFModelDescriptor {
 
 export type DMMFModels = Record<string, DMMFModelDescriptor> // key: model name
 
-const supportedCursorTypes = ['Int', 'String']
 
 export function analyseDMMF(input: DMMFDocument): DMMFModels {
   const dmmf = dmmfDocumentParser.parse(input)
@@ -40,8 +39,8 @@ export function analyseDMMF(input: DMMFDocument): DMMFModels {
       field =>
         field.isUnique && supportedCursorTypes.includes(String(field.type))
     )
-    const cursorField = model.fields.find(field =>
-      field.documentation?.includes('@encryption:cursor')
+    const cursorField = model.fields.find(
+      field => field.documentation?.includes('@encryption:cursor')
     )
     if (cursorField) {
       // Make sure custom cursor field is valid


### PR DESCRIPTION
Field encryption wasn't working on tables that had @id as BigInt type and no other @unique columns.

![image](https://github.com/47ng/prisma-field-encryption/assets/90408157/a1c8d1b7-9a9f-4498-a597-2fea29de96ae)
