### PR TITLE
fix: Support querying hash data with 'not' condition

### DIFF
--- a/src/encryption.ts
+++ b/src/encryption.ts
@@ -212,8 +212,8 @@ function rewriteHashedFieldPath(
   hashField: string
 ) {
   const items = path.split('.').reverse()
-  // Special case for `where field equals` clause
-  if (items.includes('where') && items[1] === field && items[0] === 'equals') {
+  // Special case for `where field equals or not` clause
+  if (items.includes('where') && items[1] === field && ['equals', 'not'].includes(items[0])) {
     items[1] = hashField
     return items.reverse().join('.')
   }

--- a/src/tests/integration.test.ts
+++ b/src/tests/integration.test.ts
@@ -392,14 +392,32 @@ describe.each(clients)('integration ($type)', ({ client }) => {
       expect(post).toBeNull()
       return
     }
-    // Should be unreacheable
+    // Should be unreachable
     const reached = true
     expect(reached).toBe(false)
   })
+
   test("Doesn't work with the Fluent API", async () => {
     const posts = await client.user.findUnique({ where: { email } }).posts()
     for (const post of posts!) {
       expect(post.content).toMatch(cloakedStringRegex)
     }
+  })
+
+  test("query entries with non-empty name", async () => {
+    const fakeName = 'f@keU$er'
+    await client.user.create({
+       data: {
+         name: '',
+         email: 'test_mail@example.com'
+      }
+    });
+    const users = await client.user.findMany();
+    // assume active user with nonempty name
+    const activeUserCount = await client.user.count({ where: { name: { not: '' } } })
+    // use fakeName to pretend unique name
+    const existingUsers = await client.user.findMany({ where: { name: { not: fakeName } } })
+    expect(activeUserCount).toBe(users.length - 1);
+    expect(existingUsers).toEqual(users);
   })
 })

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -84,7 +84,7 @@ export function visitInputTargetFields<
 ) {
   traverseTree(
     params.args,
-    makeVisitor(models, visitor, ['equals', 'set'], debug.encryption),
+    makeVisitor(models, visitor, ['equals', 'set', 'not'], debug.encryption),
     {
       currentModel: params.model!
     }


### PR DESCRIPTION
Hi Franky, 

I wanted to express my gratitude for your handy library – it has been immensely helpful!

However, as I mentioned in previous [issue](https://github.com/47ng/prisma-field-encryption/issues/94), filtering non-empty data becomes necessary.

While I can currently achieve this by performing two separate queries, it would be more convenient if the not condition could be applied directly.