### PR TITLE
feat: Add check to disable migration warning for specific models

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,13 @@ Migrations will look for cursor fields in your models in this order:
 If no cursor is found for a model with encrypted fields, the generator will
 throw an error when running `prisma generate`.
 
+### Disabling Migration Warnings
+
+You can use the new environment variable `DISABLE_MIGRATION_WARNING` to disable the
+warning about missing cursors. However, if a model lacks a suitable cursor and this
+warning is disabled, the `prisma generate` command will still fail to run.
+
+
 ## Key management
 
 This library is based on [@47ng/cloak](https://github.com/47ng/cloak), which comes

--- a/src/dmmf.ts
+++ b/src/dmmf.ts
@@ -32,6 +32,10 @@ export function analyseDMMF(input: DMMFDocument): DMMFModels {
   const dmmf = dmmfDocumentParser.parse(input)
   const allModels = dmmf.datamodel.models
 
+  const disabledWarningsModels = process.env.DISABLE_MIGRATION_WARNING
+    ? process.env.DISABLE_MIGRATION_WARNING.split(',')
+    : []
+
   return allModels.reduce<DMMFModels>((output, model) => {
     const idField = model.fields.find(
       field => field.isId && supportedCursorTypes.includes(String(field.type))
@@ -120,7 +124,8 @@ export function analyseDMMF(input: DMMFDocument): DMMFModels {
 
     if (
       Object.keys(modelDescriptor.fields).length > 0 &&
-      !modelDescriptor.cursor
+      !modelDescriptor.cursor &&
+      !disabledWarningsModels.includes(model.name)
     ) {
       console.warn(warnings.noCursorFound(model.name))
     }


### PR DESCRIPTION
Introduced a new check to disable migration warnings for specific models based on the presence of the `DISABLE_MIGRATION_WARNING` environment variable. This check enhances flexibility in managing migration warnings, allowing for more targeted handling of warnings according to specific model requirements.