### PR TITLE
fix: mode=strict throws when plaintext in database

### DIFF
--- a/src/encryption.ts
+++ b/src/encryption.ts
@@ -177,6 +177,9 @@ export function decryptOnRead<Models extends string, Actions extends string>(
     }) {
       try {
         if (!cloakedStringRegex.test(cipherText)) {
+          if (fieldConfig.strictDecryption) {
+            throw new Error('Value is not encrypted and mode=strict')
+          }
           return
         }
         const decryptionKey = findKeyForMessage(cipherText, keys.keychain)


### PR DESCRIPTION
Closes https://github.com/47ng/prisma-field-encryption/issues/106

I have a test locally too but I'm not sure of the process to update the test / integration SQLite DBs?