### PR TITLE
fix: support decrypting strings larger than 4 MiB

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "migrate": "ts-node ./src/tests/migrate.ts"
   },
   "dependencies": {
-    "@47ng/cloak": "^1.1.0",
+    "@47ng/cloak": "^1.2.0",
     "@prisma/generator-helper": "^5.9.1",
     "debug": "^4.3.4",
     "immer": "^10.0.3",

--- a/src/encryption.ts
+++ b/src/encryption.ts
@@ -1,11 +1,11 @@
 import {
-  cloakedStringRegex,
   CloakKeychain,
   decryptStringSync,
   encryptStringSync,
   findKeyForMessage,
   makeKeychainSync,
   ParsedCloakKey,
+  parseCloakedString,
   parseKeySync
 } from '@47ng/cloak'
 import { Draft, produce } from 'immer'
@@ -176,7 +176,7 @@ export function decryptOnRead<Models extends string, Actions extends string>(
       field
     }) {
       try {
-        if (!cloakedStringRegex.test(cipherText)) {
+        if (!parseCloakedString(cipherText)) {
           return
         }
         const decryptionKey = findKeyForMessage(cipherText, keys.keychain)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@47ng/cloak@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@47ng/cloak/-/cloak-1.1.0.tgz#4172ea63287d3c28aef3ac361fbe313d55647204"
-  integrity sha512-47dVSPgjTiH3Fgt2CATudxJAU7Fv1WjFIo2e4tXG2UcQitqmIGf9GCgv1MnGv8ctNGPAy9gsjHnNujzuZ1bOow==
+"@47ng/cloak@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@47ng/cloak/-/cloak-1.2.0.tgz#7d811527b1530ac55196c7e41fc3bb3eb0c0ac82"
+  integrity sha512-kKufIDIfW7+YdW+m/0PIFR9zsoIan04tCiAoWsvd2e/MsIh4HtU//n/xDk8eNTTl9cN/rI78qd1r2zCP0QB7hw==
   dependencies:
     "@47ng/codec" "^1.0.1"
     "@stablelib/base64" "^1.0.1"


### PR DESCRIPTION
The `cloakedStringRegex` regex fails on ciphertexts larger than 4 MiB. The new `parseCloakedString` in [`@47ng/cloak@1.2.0`][1] doesn't have this limitation.

[1]: https://github.com/47ng/cloak/releases/tag/v1.2.0

See: https://github.com/47ng/cloak/pull/411
Fixes: https://github.com/47ng/prisma-field-encryption/issues/122