### PR TITLE
docs: adds info on extending PrismaClient type in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,21 @@ and don't require a preview feature flag.
 ```ts
 import { PrismaClient } from '@prisma/client'
 import { fieldEncryptionExtension } from 'prisma-field-encryption'
+import { type PrismaClientExtends } from '@prisma/client/extension'
+import type * as runtime from '@prisma/client/runtime/library'
+
+// Define the extended client type using Prisma's extension type system
+type ExtendedClient = PrismaClient &
+  PrismaClientExtends<runtime.Types.Extensions.DefaultArgs>
 
 const globalClient = new PrismaClient()
 
 export const client = globalClient.$extends(
   // This is a function, don't forget to call it:
   fieldEncryptionExtension()
-)
+) as ExtendedClient
+
+export type { ExtendedClient as PrismaClient }
 ```
 
 Read more about how to use [Prisma client extensions](https://www.prisma.io/docs/concepts/components/prisma-client/client-extensions).


### PR DESCRIPTION
Relevant Github Issue:

https://github.com/47ng/prisma-field-encryption/issues/129

I added this in the default integration snippet because the snippet already uses Typescript, and my experience tells me it's important. Please let me know if you'd like me to keep that block of code more minimal and I can create a separate section that talks about extending the PrismaClient type.

Thanks again for your hard work on this library!