### PR TITLE
fix: normalize prisma client output paths for consistent import handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b
         with:
           node-version: lts/*
-      - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+      - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
         name: Load Yarn cache
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}

--- a/jest.config.unit.json
+++ b/jest.config.unit.json
@@ -4,5 +4,6 @@
   "coverageReporters": [["json", { "file": "coverage.unit.json" }]],
   "preset": "ts-jest/presets/js-with-ts",
   "testEnvironment": "node",
-  "testMatch": ["<rootDir>/src/*.test.[jt]s?(x)"]
+  "testMatch": ["<rootDir>/src/**/*.test.[jt]s?(x)"],
+  "testPathIgnorePatterns": ["<rootDir>/src/tests/"]
 }

--- a/src/generator/main.ts
+++ b/src/generator/main.ts
@@ -2,10 +2,10 @@
 
 import { generatorHandler } from '@prisma/generator-helper'
 import fs from 'node:fs/promises'
-import path from 'path/posix'
 import { analyseDMMF } from '../dmmf'
 import { generateIndex } from './generateIndex'
 import { generateModel } from './generateModel'
+import { getPrismaClientModule } from './prismaModule'
 
 export interface Config {
   concurrently?: boolean
@@ -42,17 +42,11 @@ generatorHandler({
     )
     const prismaClientOutput =
       prismaClient.output?.value ?? 'node_modules/@prisma/client'
-    // Normalize to forward slashes for consistent detection and import path
-    const normalizedPrismaClientOutput = prismaClientOutput.replace(/\\/g, '/')
-    let prismaClientModule: string
-    if (normalizedPrismaClientOutput.endsWith('node_modules/@prisma/client')) {
-      prismaClientModule = '@prisma/client'
-    } else {
-      // Always use forward slashes in import paths
-      prismaClientModule = path
-        .relative(outputDir, prismaClientOutput)
-        .replace(/\\/g, '/')
-    }
+
+    const prismaClientModule = getPrismaClientModule(
+      prismaClientOutput,
+      outputDir
+    )
 
     const longestModelNameLength = Object.keys(validModels).reduce(
       (max, model) => Math.max(max, model.length),

--- a/src/generator/main.ts
+++ b/src/generator/main.ts
@@ -42,12 +42,17 @@ generatorHandler({
     )
     const prismaClientOutput =
       prismaClient.output?.value ?? 'node_modules/@prisma/client'
-
-    const prismaClientModule = prismaClientOutput.endsWith(
-      'node_modules/@prisma/client'
-    )
-      ? '@prisma/client'
-      : path.relative(outputDir, prismaClientOutput)
+    // Normalize to forward slashes for consistent detection and import path
+    const normalizedPrismaClientOutput = prismaClientOutput.replace(/\\/g, '/')
+    let prismaClientModule: string
+    if (normalizedPrismaClientOutput.endsWith('node_modules/@prisma/client')) {
+      prismaClientModule = '@prisma/client'
+    } else {
+      // Always use forward slashes in import paths
+      prismaClientModule = path
+        .relative(outputDir, prismaClientOutput)
+        .replace(/\\/g, '/')
+    }
 
     const longestModelNameLength = Object.keys(validModels).reduce(
       (max, model) => Math.max(max, model.length),

--- a/src/generator/prismaModule.test.ts
+++ b/src/generator/prismaModule.test.ts
@@ -1,0 +1,41 @@
+import path from "path/posix";
+import { getPrismaClientModule } from "./prismaModule";
+
+describe("getPrismaClientModule", () => {
+  it('returns "@prisma/client" when prismaClientOutput ends with node_modules/@prisma/client (forward slashes)', () => {
+    const prismaClientOutput = "/some/project/node_modules/@prisma/client";
+    const outputDir = "/some/project/src";
+    expect(getPrismaClientModule(prismaClientOutput, outputDir)).toBe(
+      "@prisma/client"
+    );
+  });
+
+  it('returns "@prisma/client" when prismaClientOutput ends with node_modules\\@prisma\\client (backslashes)', () => {
+    const prismaClientOutput =
+      "C:\\some\\project\\node_modules\\@prisma\\client";
+    const outputDir = "C:\\some\\project\\src";
+    expect(getPrismaClientModule(prismaClientOutput, outputDir)).toBe(
+      "@prisma/client"
+    );
+  });
+
+  it("returns relative path with forward slashes if not in node_modules", () => {
+    const prismaClientOutput = "/some/project/generated/prisma-client";
+    const outputDir = "/some/project/src";
+    const expected = path
+      .relative(outputDir, prismaClientOutput)
+      .replace(/\\/g, "/");
+    expect(getPrismaClientModule(prismaClientOutput, outputDir)).toBe(expected);
+  });
+
+  it("returns relative path with forward slashes if not in node_modules (windows paths)", () => {
+    const prismaClientOutput = "C:\\some\\project\\generated\\prisma-client";
+    const outputDir = "C:\\some\\project\\src";
+    const expected = path
+      .relative(outputDir, prismaClientOutput)
+      .replace(/\\/g, "/");
+    expect(getPrismaClientModule(prismaClientOutput, outputDir)).toBe(expected);
+  });
+});
+
+// We recommend installing an extension to run jest tests.

--- a/src/generator/prismaModule.ts
+++ b/src/generator/prismaModule.ts
@@ -1,0 +1,19 @@
+import path from 'path/posix'
+
+export function getPrismaClientModule(
+  prismaClientOutput: string,
+  outputDir: string
+): string {
+  // Normalize to forward slashes for consistent detection and import path
+  const normalizedPrismaClientOutput = prismaClientOutput.replace(/\\/g, '/')
+  let prismaClientModule: string
+  if (normalizedPrismaClientOutput.endsWith('node_modules/@prisma/client')) {
+    prismaClientModule = '@prisma/client'
+  } else {
+    // Always use forward slashes in import paths
+    prismaClientModule = path
+      .relative(outputDir, prismaClientOutput)
+      .replace(/\\/g, '/')
+  }
+  return prismaClientModule
+}


### PR DESCRIPTION
Fixes #140
I implemented normalization of the prisma client output path before checking the ending against `'node_modules/@prisma/client'`.

I am unsure how to go about creating the unit test, because it should mock the `prismaClient.output?.value` being in windows path style and running the `onGenerate` function.
Any ideas how to implement this unit test?